### PR TITLE
Add secret scan workflow

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,25 @@
+# Secret scanning workflow.
+name: Secret Scan
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  secret-scan:
+    name: Secret Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version: '1.24.x'
+          cache: false
+      - name: Scan for hard-coded secrets
+        run: go run ./scripts/secret_scan/main.go -files="$(git ls-files | tr '\n' ',')"

--- a/examples/basic-tls/main.tf
+++ b/examples/basic-tls/main.tf
@@ -7,14 +7,12 @@ locals {
 variable "warpstream_virtual_cluster_id" {
   description = "The warpstream virtual cluster id"
   type        = string
-  default     = "vci_d0821d64_e6c1_4322_b327_bbf3093b74e1"
 }
 
 variable "warpstream_agent_key" {
   description = "The agent key for the warpstream cluster"
   type        = string
   sensitive   = true
-  default     = "YOUR_AGENT_KEY"
 }
 
 provider "aws" {

--- a/examples/basic-tls/main.tf
+++ b/examples/basic-tls/main.tf
@@ -14,7 +14,7 @@ variable "warpstream_agent_key" {
   description = "The agent key for the warpstream cluster"
   type        = string
   sensitive   = true
-  default     = "aks_8767614f91aee4b7d9185f15e387b9f1c496bd58357e146ced0a453249d5fe2c"
+  default     = "YOUR_AGENT_KEY"
 }
 
 provider "aws" {

--- a/scripts/secret_scan/main.go
+++ b/scripts/secret_scan/main.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+var (
+	prefixes = []string{
+		// API Key.
+		"aks_[0-9a-f]{20,}",
+		// Cluster credentials password.
+		"ccp_[0-9a-f]{20,}",
+		// Session key secret.
+		"sks_[0-9a-f]{20,}",
+	}
+
+	allowedKeys = map[string]struct{}{}
+)
+
+func main() {
+	filesFlag := flag.String("files", "", "Comma-separated list of files to scan")
+	flag.Parse()
+
+	if *filesFlag == "" {
+		fmt.Println("Usage: scanner -files=<comma-separated-files>")
+		os.Exit(1)
+	}
+
+	var (
+		files         = strings.Split(*filesFlag, ",")
+		prefixPattern = strings.Join(prefixes, "|")
+		regex         = regexp.MustCompile(prefixPattern)
+	)
+
+	hasIssues := false
+	for _, file := range files {
+		if file == "" {
+			continue
+		}
+
+		f, err := os.Open(file)
+		if err != nil {
+			fmt.Printf("Error opening file %s: %v\n", file, err)
+			os.Exit(1)
+		}
+
+		scanner := bufio.NewScanner(f)
+		lineNumber := 1
+		for scanner.Scan() {
+			line := scanner.Text()
+			matches := regex.FindAllString(line, -1)
+			for _, match := range matches {
+				if _, allowed := allowedKeys[match]; allowed {
+					continue
+				}
+
+				fmt.Printf("Found illegal prefix (potential secret?) in %s at line %d: %s\n", file, lineNumber, line)
+				hasIssues = true
+			}
+			lineNumber++
+		}
+
+		if err := scanner.Err(); err != nil {
+			fmt.Printf("Error reading file %s: %v\n", file, err)
+			if closeErr := f.Close(); closeErr != nil {
+				fmt.Printf("Error closing file %s: %v\n", file, closeErr)
+			}
+			os.Exit(1)
+		}
+
+		if err := f.Close(); err != nil {
+			fmt.Printf("Error closing file %s: %v\n", file, err)
+			os.Exit(1)
+		}
+	}
+
+	if hasIssues {
+		fmt.Println("Illegal prefixes (potential secret?) found.")
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
## Summary
- Add a dedicated Secret Scan workflow for pull requests and pushes to main.
- Add a small scanner that rejects hard-coded WarpStream API keys and related secrets.
- Replace the TLS example's concrete agent key with a placeholder.